### PR TITLE
fix: write Arrow footer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -115,5 +115,5 @@ fn main() -> Result<(), ArrowError> {
         }
     }
 
-    Ok(())
+    writer.finish()
 }


### PR DESCRIPTION
The resulting Arrow IPC file is invalid because it's missing the footer. Calling `finish` after writing all the batches fixes this.